### PR TITLE
20w21a Fixes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.4.3'
+    id 'fabric-loom' version '0.4.15'
 }
 
 sourceCompatibility = 1.8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 #Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
-mod_version=5.2.1-unstable
-minecraftVersion=20w18a
-yarnVersion=20w18a+build.1
-fabricVersion=0.7.0+build.330-1.16
+mod_version=5.2.2-unstable
+minecraftVersion=20w21a
+yarnVersion=20w21a+build.9
+fabricVersion=0.10.9+build.346-1.16
 cloth_version=2.2.0-unstable
-cloth_config_version=4.0.4-unstable
-loaderVersion=0.8.2+build.194
-modmenuVersion=1.11.2+build.6
+cloth_config_version=4.4.0-unstable
+loaderVersion=0.8.4+build.198
+modmenuVersion=1.11.6+build.11

--- a/src/main/java/me/shedaniel/lightoverlay/fabric/mixin/MixinClientConnection.java
+++ b/src/main/java/me/shedaniel/lightoverlay/fabric/mixin/MixinClientConnection.java
@@ -16,7 +16,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ClientConnection.class)
 public class MixinClientConnection {
     @Inject(method = "handlePacket", at = @At("HEAD"))
-    private static void handlePacket(Packet packet, PacketListener listener, CallbackInfo ci) {
+    private static void handlePacket(Packet<?> packet, PacketListener listener, CallbackInfo ci) {
         if (packet instanceof BlockUpdateS2CPacket) {
             LightOverlay.queueChunkAndNear(new ChunkPos(((BlockUpdateS2CPacket) packet).getPos()));
         } else if (packet instanceof ChunkDataS2CPacket) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,38 +1,38 @@
 {
-  "schemaVersion": 1,
-  "id": "lightoverlay",
-  "name": "Light Overlay",
-  "description": "To provide users with NEI-like light overlay.",
-  "version": "${version}",
-  "environment": "client",
-  "authors": [
-    "shedaniel"
-  ],
-  "contact": {
-    "homepage": "https://minecraft.curseforge.com/projects/light-overlay",
-    "sources": "https://github.com/shedaniel/LightOverlay-Fabric",
-    "issues": "https://github.com/shedaniel/LightOverlay-Fabric/issues"
-  },
-  "entrypoints": {
-    "client": [
-      "me.shedaniel.lightoverlay.fabric.LightOverlay"
-    ],
-    "modmenu": [
-      "me.shedaniel.lightoverlay.fabric.LOModMenuEntry"
-    ]
-  },
-  "license": "Apache-2.0",
-  "icon": "icon.png",
-  "requires": {
-    "fabricloader": ">=0.4.0",
-    "cloth": "~2-",
-    "minecraft": "~1.16-Snapshot.20.13.b"
-  },
-  "mixins": [
-    "lightoverlay.mixins.json"
-  ],
-  "accessWidener": "lightoverlay.accesswidener",
-  "custom": {
-    "modmenu:clientsideOnly": true
-  }
+	"schemaVersion": 1,
+	"id": "lightoverlay",
+	"name": "Light Overlay",
+	"description": "To provide users with NEI-like light overlay.",
+	"version": "${version}",
+	"environment": "client",
+	"authors": [
+		"shedaniel"
+	],
+	"contact": {
+		"homepage": "https://minecraft.curseforge.com/projects/light-overlay",
+		"sources": "https://github.com/shedaniel/LightOverlay-Fabric",
+		"issues": "https://github.com/shedaniel/LightOverlay-Fabric/issues"
+	},
+	"entrypoints": {
+		"client": [
+			"me.shedaniel.lightoverlay.fabric.LightOverlay"
+		],
+		"modmenu": [
+			"me.shedaniel.lightoverlay.fabric.LOModMenuEntry"
+		]
+	},
+	"license": "Apache-2.0",
+	"icon": "icon.png",
+	"depends": {
+		"fabricloader": ">=0.8.4",
+		"cloth": "~2.2-",
+		"minecraft": "~1.16-Snapshot.20.21.a"
+	},
+	"mixins": [
+		"lightoverlay.mixins.json"
+	],
+	"accessWidener": "lightoverlay.accesswidener",
+	"custom": {
+		"modmenu:clientsideOnly": true
+	}
 }


### PR DESCRIPTION
# 20w21a Fixes.

Should be properly working in the latest snapshot; did some minor testing both in singleplayer and multiplayer.

These two Fabric changes are what broke the current version ([v5.2.1-unstable](https://github.com/shedaniel/LightOverlay/commit/04ee0a292d8985c6c282e2f61ad2aec8d1ea68a4)):
- [FabricMC/yarn/pull#1327](https://github.com/FabricMC/yarn/pull/1327)
- [FabricMC/yarn/issues#1301](https://github.com/FabricMC/yarn/issues/1301)

# **Changelog:**

## [Library updates]
- Updated fabric-loader to **'0.8.4+build.198'**.
- Updated fabric-api to **'0.10.9+build.346-1.16'**.
- Updated yarn to **'20w21a+build.9'**.
- Updated cloth-config to **'4.4.0-unstable'**.
- Updated modmenu to **'1.11.6+build.11'**.

## [Overlay]
- Renamed the following classes/methods:
  - [EntityCategory >> SpawnGroup](https://github.com/FabricMC/yarn/pull/1327).
  - [Biome#getMaxSpawnLimit() >> Biome#getMaxSpawnChance().](https://github.com/FabricMC/yarn/issues/1301)
- Removed unnecessary warning supression for renderLevel() ([L#240](https://github.com/pacoito123/LightOverlay/blob/1.16/src/main/java/me/shedaniel/lightoverlay/fabric/LightOverlay.java#L240)).
- Moved MinecraftClient.getInstance() calls to a single variable ([L#81](https://github.com/pacoito123/LightOverlay/blob/1.16/src/main/java/me/shedaniel/lightoverlay/fabric/LightOverlay.java#L81)):
  - Should work the same, but without the 'resource leak' warnings.

## [Mixin]
- Added <?> wildcard to handlePacket() ([L#19](https://github.com/pacoito123/LightOverlay/blob/1.16/src/main/java/me/shedaniel/lightoverlay/fabric/mixin/MixinClientConnection.java#L19)), removes param warning.

## [Other]
- Updated dependencies in ['fabric.mod.json'](https://github.com/pacoito123/LightOverlay/blob/1.16/src/main/resources/fabric.mod.json):
  - Changed keyword ['requires' to 'depends'](https://github.com/pacoito123/LightOverlay/blob/1.16/src/main/resources/fabric.mod.json#L26) to remove warning on launch.