### PR TITLE
Remove deprecated modmenu:clientsideOnly

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -27,9 +27,6 @@
     "lightoverlay.mixins.json"
   ],
   "accessWidener": "lightoverlay.accesswidener",
-  "custom": {
-    "modmenu:clientsideOnly": true
-  },
   "depends": {
     "fabric": ">=0.29.1",
     "architectury": ">=2-",


### PR DESCRIPTION
Update to latest ModMenu API, eliminating a deprecation warning to maintain future-proof compatibility:
`WARNING! Mod lightoverlay is only using deprecated 'modmenu:clientsideOnly' custom value! This is no longer needed and will be removed in 1.18 snapshots`

As per [ModMenu API](https://github.com/TerraformersMC/ModMenu/wiki/API):
> There are more badges, such as the Client badge, but this is automatically determined by the environment defined in the official `fabric.mod.json` metadata